### PR TITLE
Add Code Climate config and fixes Rubocop config.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,15 @@
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: true
+ratings:
+  paths:
+  - "**.rb"
+exclude_paths:
+- spec/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 # https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 
 AllCops:
-  TargetRubyVersion: 2.3.3
+  TargetRubyVersion: 2.3
 
 Metrics/LineLength:
   Max: 110


### PR DESCRIPTION
Hi, this is Abby from Code Climate! There's more information in the email I've sent, but this pull request:

- In `rubocop.yml`, changes `TargetRubyVersion` to `2.3` 
- Adds inferred .codeclimate.yml for Code Climate configuration.

Thanks! 